### PR TITLE
Fix bug in pathname parser

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -724,9 +724,10 @@ PARSE_PATHNAME:
         // set chk_scheme to 0 if not scheme characters
         case '!':
         case '$':
-        // 0x24-2A = "&" "'" "(" ")" "*"
+        // 0x24-2A = & ' ( ) *
         case '&' ... '*':
         case ',':
+        case '.':
         case '/':
         case ';':
         case '=':

--- a/test/parse_test.lua
+++ b/test/parse_test.lua
@@ -189,6 +189,20 @@ function testcase.parse_without_userinfo_port_pathname_query_fragment()
     })
 end
 
+function testcase.parse_without_scheme()
+    -- test that parse url without scheme, userinfo, port, pathname, query and fragment
+    local segments = {
+        'host.com:8080',
+    }
+    local s = concat(segments)
+    local u, cur, err = parse(s)
+    assert.equal(cur, #s)
+    assert.is_nil(err)
+    assert.equal(u, {
+        path = 'host.com:8080',
+    })
+end
+
 function testcase.parse_without_authority()
     -- test that parse file scheme
     local segments = {


### PR DESCRIPTION
disable the scheme parser if a dot character is exist.